### PR TITLE
Second 1.19 patch.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>mineverse.Aust1n46.chat</groupId>
     <artifactId>VentureChat</artifactId>
-    <version>3.3.2</version>
+    <version>3.4.1_1.19_patch</version>
     <url>https://bitbucket.org/Aust1n46/venturechat/src/master</url>
     <scm>
         <url>https://bitbucket.org/Aust1n46/venturechat/src/master</url>
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.6.0</version>
+            <version>5.0.0-SNAPSHOT</version>
         </dependency>
         <!--These are long depreciated. I would've removed them, but that is outside the scope of what I want to do here.
         I am using the latest builds of these plugins to be published to SpigotMC.-->
@@ -218,7 +218,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.13-R0.1-SNAPSHOT</version>
+            <version>1.19-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/mineverse/Aust1n46/chat/MineverseChat.java
+++ b/src/main/java/mineverse/Aust1n46/chat/MineverseChat.java
@@ -42,11 +42,12 @@ import mineverse.Aust1n46.chat.json.JsonFormat;
 import mineverse.Aust1n46.chat.listeners.ChatListener;
 import mineverse.Aust1n46.chat.listeners.CommandListener;
 import mineverse.Aust1n46.chat.listeners.LoginListener;
-import mineverse.Aust1n46.chat.listeners.PacketListener;
+import mineverse.Aust1n46.chat.listeners.PacketListenerLegacyChat;
 import mineverse.Aust1n46.chat.listeners.SignListener;
 import mineverse.Aust1n46.chat.localization.Localization;
 import mineverse.Aust1n46.chat.localization.LocalizedMessage;
 import mineverse.Aust1n46.chat.utilities.Format;
+import mineverse.Aust1n46.chat.versions.VersionHandler;
 import net.milkbowl.vault.chat.Chat;
 import net.milkbowl.vault.permission.Permission;
 
@@ -217,7 +218,9 @@ public class MineverseChat extends JavaPlugin implements PluginMessageListener {
 		pluginManager.registerEvents(new SignListener(), this);
 		pluginManager.registerEvents(new CommandListener(), this);
 		pluginManager.registerEvents(new LoginListener(), this);
-		ProtocolLibrary.getProtocolManager().addPacketListener(new PacketListener());
+		if (VersionHandler.isUnder_1_19()) {
+			ProtocolLibrary.getProtocolManager().addPacketListener(new PacketListenerLegacyChat());
+		}
 	}
 	
 	private boolean setupPermissions() {

--- a/src/main/java/mineverse/Aust1n46/chat/listeners/PacketListenerLegacyChat.java
+++ b/src/main/java/mineverse/Aust1n46/chat/listeners/PacketListenerLegacyChat.java
@@ -14,20 +14,16 @@ import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
 
-//This class listens for chat packets and intercepts them before they are sent to the Player.
-//The packets are modified to include advanced json formating and the message remover button if the 
-//player has permission to remove messages.
-public class PacketListener extends PacketAdapter {
-	public PacketListener() {
+public class PacketListenerLegacyChat extends PacketAdapter {
+	public PacketListenerLegacyChat() {
 		super(MineverseChat.getInstance(), ListenerPriority.MONITOR, new PacketType[] { PacketType.Play.Server.CHAT });
 	}
 
 	@Override
 	public void onPacketSending(PacketEvent event) {
-		if(event.isCancelled() || event.getPacketType() != PacketType.Play.Server.CHAT) {
+		if(event.isCancelled()) {
 			return;
 		}
-		
 		MineverseChatPlayer mcp = MineverseChatAPI.getOnlineMineverseChatPlayer(event.getPlayer());
 		if(mcp == null) {
 			return;
@@ -38,7 +34,6 @@ public class PacketListener extends PacketAdapter {
 		if(chat == null) {
 			return;
 		}
-		
 		try {
 			if(VersionHandler.is1_7()) {
 				packet.getBooleans().getField(0).setAccessible(true);
@@ -57,12 +52,11 @@ public class PacketListener extends PacketAdapter {
 				if(packet.getChatTypes().getField(0).get(packet.getHandle()) == packet.getChatTypes().getField(0).getType().getEnumConstants()[2]) {
 					return;
 				}
-			}
+			} 
 		}
 		catch(Exception e) {
 			e.printStackTrace();
 		}
-		
 		String message = Format.toPlainText(chat.getHandle(), chat.getHandleType());
 		String coloredMessage = Format.toColoredText(chat.getHandle(), chat.getHandleType());
 		if(message == null) {

--- a/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
+++ b/src/main/java/mineverse/Aust1n46/chat/utilities/Format.java
@@ -429,17 +429,31 @@ public class Format {
 	}
 
 	public static PacketContainer createPacketPlayOutChat(String json) {
-		WrappedChatComponent component = WrappedChatComponent.fromJson(json);
-		PacketContainer container = new PacketContainer(PacketType.Play.Server.CHAT);
-		container.getModifier().writeDefaults();
-		container.getChatComponents().write(0, component);
+		final PacketContainer container;
+		if (VersionHandler.isUnder_1_19()) {
+			WrappedChatComponent component = WrappedChatComponent.fromJson(json);
+			container = new PacketContainer(PacketType.Play.Server.CHAT);
+			container.getModifier().writeDefaults();
+			container.getChatComponents().write(0, component);
+		} else {
+			container = new PacketContainer(PacketType.Play.Server.SYSTEM_CHAT);
+			container.getStrings().write(0, json);
+			container.getIntegers().write(0, 1);
+		}
 		return container;
 	}
 
 	public static PacketContainer createPacketPlayOutChat(WrappedChatComponent component) {
-		PacketContainer container = new PacketContainer(PacketType.Play.Server.CHAT);
-		container.getModifier().writeDefaults();
-		container.getChatComponents().write(0, component);
+		final PacketContainer container;
+		if (VersionHandler.isUnder_1_19()) {
+			container = new PacketContainer(PacketType.Play.Server.CHAT);
+			container.getModifier().writeDefaults();
+			container.getChatComponents().write(0, component);
+		} else {
+			container = new PacketContainer(PacketType.Play.Server.SYSTEM_CHAT);
+			container.getStrings().write(0, component.getJson());
+			container.getIntegers().write(0, 1);
+		}
 		return container;
 	}
 

--- a/src/main/java/mineverse/Aust1n46/chat/versions/VersionHandler.java
+++ b/src/main/java/mineverse/Aust1n46/chat/versions/VersionHandler.java
@@ -52,4 +52,16 @@ public class VersionHandler {
 	public static boolean is1_17() {
 		return Bukkit.getVersion().contains("1.17");
 	}
+	
+	public static boolean is1_18() {
+		return Bukkit.getVersion().contains("1.18");
+	}
+	
+	public static boolean is1_19() {
+		return Bukkit.getVersion().contains("1.19");
+	}
+	
+	public static boolean isUnder_1_19() {
+		return is1_7() || is1_8() || is1_9() || is1_10() || is1_11() || is1_12() || is1_13() || is1_14() || is1_15() || is1_16() || is1_17() || is1_18();
+	}
 }


### PR DESCRIPTION
Should be backwards compatible.
Message remover packet listener completely removed for 1.19.